### PR TITLE
Fixed handling of body for GET requests.

### DIFF
--- a/betable-browser-sdk.js
+++ b/betable-browser-sdk.js
@@ -112,7 +112,7 @@ Betable.prototype.xhr = function Betable_xhr(
 
     if ('GET' === method && body) {
         Object.keys(body).forEach(function(key) {
-            path += '&' + encodeURIComponent(key) + '=' + encodeURIComponent(body[key])
+            xhr_args[1] += '&' + encodeURIComponent(key) + '=' + encodeURIComponent(body[key])
         })
     }
 


### PR DESCRIPTION
Betable.prototype.xhr was not sending the body as query string parameters for GET requests.
