### PR TITLE
IE8 through 10 does not send the right content type for betCredits CORS ...

### DIFF
--- a/betable-browser-sdk.js
+++ b/betable-browser-sdk.js
@@ -54,6 +54,7 @@ Betable.prototype.betCredits = function Betable_betCredits(gameId, options, call
       , options
       , callback
       , errback
+      , true
     )
 }
 


### PR DESCRIPTION
...requests

Sending a bet credit request through betCredits via CORS will faill on IE10 if the request is sent with XDomainRequest, that method does not send other content types than text/plain.

See this link for more information: http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx
